### PR TITLE
Upgrade to Sucker Punch 2.0

### DIFF
--- a/fist_of_fury.gemspec
+++ b/fist_of_fury.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |gem|
     gem.add_development_dependency 'coveralls'
   end
 
-  gem.add_dependency 'sucker_punch', '~> 1.5.0'
+  gem.add_dependency 'sucker_punch', '~> 2.0.0'
+  gem.add_dependency 'celluloid',    '~> 0.17.2'
   gem.add_dependency 'ice_cube',     '~> 0.11.3'
 end

--- a/lib/fist_of_fury.rb
+++ b/lib/fist_of_fury.rb
@@ -1,13 +1,14 @@
 # stdlib
 require 'ostruct'
-require 'singleton'
-require 'socket'
+# require 'singleton'
+# require 'socket'
 require 'time'
 
 # gems
 require 'ice_cube'
 require 'sucker_punch'
-require 'celluloid'
+require 'sucker_punch/async_syntax' # Add support for Sucker Punch 2.0
+require 'celluloid/current'
 
 # internal
 require 'fist_of_fury/config'

--- a/lib/fist_of_fury/supervisor.rb
+++ b/lib/fist_of_fury/supervisor.rb
@@ -1,6 +1,6 @@
 module FistOfFury
-  class Supervisor < Celluloid::SupervisionGroup
-    supervise FistOfFury::Actor::Clock, as: :fist_of_fury_clock
+  class Supervisor < Celluloid::Supervision::Container 
+    supervise type: FistOfFury::Actor::Clock, as: :fist_of_fury_clock
     # TODO: configurable pool size. For now, use Celluloid's CPU-based default.
     pool FistOfFury::Actor::Dispatcher, as: :fist_of_fury_dispatcher
 


### PR DESCRIPTION
This PR adds support for sucker_punch ~> 2.0.  Changes: 
1. Add Celluloid as a dependency in gemspec, as it is no longer implicit (since Sucker Punch now uses concurrent-ruby), and bump sucker_punch dependency to 2.0. 
2. Include sucker_punch/async_syntax to add support for Sucker Punch 2.0 
3. Fix issue with Celluloid changing namespacing for SupervisionGroup to Celluloid::Supervision::Container. 

One spec is currently not passing: `rspec ./spec/fist_of_fury_spec.rb:12 # FistOfFury#logger delegates to Sucker Punch's logger`.  Full error message: 

```
Failure/Error: expect(FistOfFury.logger).to eq SuckerPunch.logger

       expected: #<Logger:0x00000003a431b8 @progname=nil, @level=1, @default_formatter=#<Logger::Formatter:0x00000003a43190 @datetime_format=nil>, @formatter=nil, @logdev=#<Logger::LogDevice:0x00000003a43140 @shift_size=nil, @shift_age=nil, @filename=nil, @dev=#<IO:<STDOUT>>, @mon_owner=nil, @mon_count=0, @mon_mutex=#<Thread::Mutex:0x00000003a43118>>>
            got: #<Logger:0x00000003a432a8 @progname=nil, @level=1, @default_formatter=#<Logger::Formatter:0x00000003a43280 @datetime_format=nil>, @formatter=nil, @logdev=#<Logger::LogDevice:0x00000003a43230 @shift_size=nil, @shift_age=nil, @filename=nil, @dev=#<IO:<STDOUT>>, @mon_owner=nil, @mon_count=0, @mon_mutex=#<Thread::Mutex:0x00000003a43208>>>

       (compared using ==)

       Diff:


       @@ -1,13 +1,13 @@
       -#<Logger:0x00000003a431b8
       - @default_formatter=#<Logger::Formatter:0x00000003a43190 @datetime_format=nil>,
       +#<Logger:0x00000003a432a8
       + @default_formatter=#<Logger::Formatter:0x00000003a43280 @datetime_format=nil>,
         @formatter=nil,
         @level=1,
         @logdev=
       -  #<Logger::LogDevice:0x00000003a43140
       +  #<Logger::LogDevice:0x00000003a43230
           @dev=#<IO:<STDOUT>>,
           @filename=nil,
           @mon_count=0,
       -   @mon_mutex=#<Thread::Mutex:0x00000003a43118>,
       +   @mon_mutex=#<Thread::Mutex:0x00000003a43208>,
           @mon_owner=nil,
           @shift_age=nil,
           @shift_size=nil>,

     # ./spec/fist_of_fury_spec.rb:13:in `block (3 levels) in <top (required)>'
```

 I believe this is because Fist of Fury is using Celluloid and Sucker Punch is using concurrent-ruby, both of which initialize the logger in different threads.  Not sure how to fix this.  
